### PR TITLE
Conditionally render certain interface components

### DIFF
--- a/src/client/components/GameInterface.js
+++ b/src/client/components/GameInterface.js
@@ -10,18 +10,26 @@ export default class GameInterface extends React.Component {
   }
   
   render() {
+    let isDrawer = this.props.isDrawer;
+    let isGameInProgress = this.props.isGameInProgress;
     return (
       <div id="top-message">
-        <GameStatusControls
-          onDrawRequest={this.props.onDrawRequest}
-         />
-         {this.props.word}
-        <Guessbox 
-          submitGuess={this.props.onGuessSubmit}
-        />
-        <GuessList
-          guesses={this.props.guesses}
-         />
+        { !isGameInProgress &&
+          <GameStatusControls
+            onDrawRequest={this.props.onDrawRequest}
+          />
+        }
+        {this.props.word}
+        { isGameInProgress && !isDrawer &&
+          <Guessbox 
+            submitGuess={this.props.onGuessSubmit}
+          />
+        }
+        { isGameInProgress &&
+          <GuessList
+            guesses={this.props.guesses}
+          />
+        }
       </div>
     );
   }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -70,6 +70,8 @@ class PictionaryApp extends React.Component {
           onGuessSubmit={this.handleGuessSubmit.bind(this)}
           word={this.state.word}
           guesses={this.state.guesses}
+          isGameInProgress={this.state.gameInProgress}
+          isDrawer={this.state.isDrawer}
         />
         <DrawingArea
           userCanDraw={this.state.isDrawer}


### PR DESCRIPTION
Depending on the state of application, a user may be in the role
of a drawer or a guesser. The React app keeps track of this state and
sends that state via props to the game interface. Within the interface,
we can use short circuited comparators evaluated within the JSX
to conditionally render components depending on the role of the user.'

Closes #33
Closes #40